### PR TITLE
Add instructions on how to add additional devices

### DIFF
--- a/telemetry-to-azure-iot-edge/README.md
+++ b/telemetry-to-azure-iot-edge/README.md
@@ -307,7 +307,7 @@ sudo iotedge check
 
 At this point the IoT Edge runtime is configured to accept MQTT connections from a camera.
 
-### Configuring the camera
+### Configure the camera
 
 Now that the edge gateway is ready to accept telemetry, let's continue with configuring the camera to send events.
 

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -162,8 +162,8 @@ openssl genrsa -out "$device_identity.key" 2048
 openssl req -new -key "$device_identity.key" -subj "/CN=$device_identity" \
    -out "$device_identity.csr"
 
-# Convert the CA certificate from PFX format to PEM format (press enter when
-# asked for password)
+# Convert the downloaded CA certificate from PFX format to PEM format (press
+# enter when asked for password)
 openssl pkcs12 -in "$ca_path" -nodes -out ca.pem
 
 # Create the new device certificate

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -162,7 +162,8 @@ openssl genrsa -out "$device_identity.key" 2048
 openssl req -new -key "$device_identity.key" -subj "/CN=$device_identity" \
    -out "$device_identity.csr"
 
-# Convert the CA certificate from PFX format to PEM format
+# Convert the CA certificate from PFX format to PEM format (press enter when
+# asked for password)
 openssl pkcs12 -in "$ca_path" -nodes -out ca.pem
 
 # Create the new device certificate

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -149,14 +149,27 @@ With the new device created, navigate to your Key Vault instance and select *Cer
 With the CA certificate downloaded, and assumed to have the name `keyvault.pfx`, please open a terminal and run the following commands to create a new device certificate. At this point you will need to have [OpenSSL](https://www.openssl.org/) installed on your computer.
 
 ```
+# Define a variable with the name of the new device
 device_identity=device02
+
+# Define a variable pointing at the downloaded CA certificate
 ca_path=keyvault.pfx
+
+# Generate a new private key
 openssl genrsa -out "$device_identity.key" 2048
+
+# Generate a new certificate signing request (CSR)
 openssl req -new -key "$device_identity.key" -subj "/CN=$device_identity" \
    -out "$device_identity.csr"
+
+# Convert the CA certificate from PFX format to PEM format
 openssl pkcs12 -in "$ca_path" -nodes -out ca.pem
+
+# Create the new device certificate
 openssl x509 -req -in "$device_identity.csr" -CA ca.pem -CAcreateserial \
    -days 365 -sha256 -out "$device_identity.pem"
+
+# Convert the device certificate from PEM format to PFX format
 openssl pkcs12 -inkey "$device_identity.key" -in "$device_identity.pem" -export \
    -passout pass: -out "$device_identity.pfx"
 ```

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -161,7 +161,7 @@ $ openssl pkcs12 -inkey "$device_identity.key" -in "$device_identity.pem" -expor
    -passout pass: -out "$device_identity.pfx"
 ```
 
-With the new device certificate `device02.pfx` created, please proceed to upload the certificate to the camera, and configure the camera using the same steps as the first camera in the application.
+With the new device certificate `device02.pfx` created, please proceed to upload the certificate to the camera, and then configure the camera using the same steps as the first camera in the application.
 
 
 ## Cleanup

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -146,7 +146,7 @@ Assuming that the new device will be named `device02`, enter the following infor
 
 With the new device created, navigate to your Key Vault instance and select *Certificates* under *Settings* in the left pane. Click the `ca` certificate and download it in the same way as you previously downloaded the `device` certificate.
 
-With the CA certificate downloaded and assumed to have the name `keyvault.pfx`, please open a terminal and run the following commands to create a new device certificate. You will at this point need the have [OpenSSL](https://www.openssl.org/) installed on your computer.
+With the CA certificate downloaded, and assumed to have the name `keyvault.pfx`, please open a terminal and run the following commands to create a new device certificate. At this point you will need the have [OpenSSL](https://www.openssl.org/) installed on your computer.
 
 ```
 $ device_identity=device02

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -144,7 +144,7 @@ Assuming that the new device will be named `device02`, enter the following infor
 - **Device ID**: `device02`
 - **Authentication type**: `X.509 CA Signed`
 
-With the new device created, navigate to your Key Vault instance and select *Certificates* under *Settings* in the left pane. Click the `ca` certificate and download it in the same way as you previously downloaded the `device` certificate.
+With the new Azure IoT device created, navigate to your Key Vault instance and select *Certificates* under *Settings* in the left pane. Click the `ca` certificate and download it in the same way as you previously downloaded the `device` certificate.
 
 With the CA certificate downloaded, and assumed to have the name `keyvault.pfx`, please open a terminal and run the following commands to create a new device certificate. At this point you will need to have [OpenSSL](https://www.openssl.org/) installed on your computer.
 

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -135,6 +135,35 @@ At this point the camera is sending a new event every 5 seconds to the Azure IoT
 az iot hub monitor-events --hub-name <iot hub name>
 ```
 
+### Add additional IoT devices
+
+To add additional IoT devices to your deployed application, please open [Azure Portal](https://portal.azure.com) in a web browser and navigate to the deployed IoT Hub. In the IoT Hub, select *Devices* under *Device management* in the left pane, and then click the *Add Device* toolbar button.
+
+Assuming that the new device will be named `device02`, enter the following information and then click the *Save* button.
+
+- **Device ID**: `device02`
+- **Authentication type**: `X.509 CA Signed`
+
+With the new device created, navigate to your Key Vault instance and select *Certificates* under *Settings* in the left pane. Click the `ca` certificate and download it in the same way as you previously downloaded the `device` certificate.
+
+With the CA certificate downloaded and assumed to have the name `keyvault.pfx`, please open a terminal and run the following commands to create a new device certificate. You will at this point need the have [OpenSSL](https://www.openssl.org/) installed on your computer.
+
+```
+$ device_identity=device02
+$ ca_path=keyvault.pfx
+$ openssl genrsa -out "$device_identity.key" 2048
+$ openssl req -new -key "$device_identity.key" -subj "/CN=$device_identity" \
+   -out "$device_identity.csr"
+$ openssl pkcs12 -in "$ca_path" -nodes -out ca.pem
+$ openssl x509 -req -in "$device_identity.csr" -CA ca.pem -CAcreateserial \
+   -days 365 -sha256 -out "$device_identity.pem"
+$ openssl pkcs12 -inkey "$device_identity.key" -in "$device_identity.pem" -export \
+   -passout pass: -out "$device_identity.pfx"
+```
+
+With the new device certificate `device02.pfx` created, please proceed to upload the certificate to the camera, and configure the camera using the same steps as the first camera in the application.
+
+
 ## Cleanup
 
 To delete all deployed resources in Azure, run the following CLI command

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -66,7 +66,7 @@ Once the deployment is complete, navigate to the *Outputs* tab and take note of 
 
 ![Outputs](./assets/outputs.png)
 
-### Configuring the camera
+### Configure the camera
 
 Now that the resources in Azure are ready to accept telemetry, let's continue with configuring the camera to send events.
 

--- a/telemetry-to-azure-iot-hub/README.md
+++ b/telemetry-to-azure-iot-hub/README.md
@@ -146,18 +146,18 @@ Assuming that the new device will be named `device02`, enter the following infor
 
 With the new device created, navigate to your Key Vault instance and select *Certificates* under *Settings* in the left pane. Click the `ca` certificate and download it in the same way as you previously downloaded the `device` certificate.
 
-With the CA certificate downloaded, and assumed to have the name `keyvault.pfx`, please open a terminal and run the following commands to create a new device certificate. At this point you will need the have [OpenSSL](https://www.openssl.org/) installed on your computer.
+With the CA certificate downloaded, and assumed to have the name `keyvault.pfx`, please open a terminal and run the following commands to create a new device certificate. At this point you will need to have [OpenSSL](https://www.openssl.org/) installed on your computer.
 
 ```
-$ device_identity=device02
-$ ca_path=keyvault.pfx
-$ openssl genrsa -out "$device_identity.key" 2048
-$ openssl req -new -key "$device_identity.key" -subj "/CN=$device_identity" \
+device_identity=device02
+ca_path=keyvault.pfx
+openssl genrsa -out "$device_identity.key" 2048
+openssl req -new -key "$device_identity.key" -subj "/CN=$device_identity" \
    -out "$device_identity.csr"
-$ openssl pkcs12 -in "$ca_path" -nodes -out ca.pem
-$ openssl x509 -req -in "$device_identity.csr" -CA ca.pem -CAcreateserial \
+openssl pkcs12 -in "$ca_path" -nodes -out ca.pem
+openssl x509 -req -in "$device_identity.csr" -CA ca.pem -CAcreateserial \
    -days 365 -sha256 -out "$device_identity.pem"
-$ openssl pkcs12 -inkey "$device_identity.key" -in "$device_identity.pem" -export \
+openssl pkcs12 -inkey "$device_identity.key" -in "$device_identity.pem" -export \
    -passout pass: -out "$device_identity.pfx"
 ```
 


### PR DESCRIPTION
Deploying the application using the deploy button is easy, but adding additional devices to the application is not apparent to a reader.

Let's add instructions on how to accomplish that given an initial deployment.