### PR TITLE
CONTRIBUTING.md: Use single quotes for static sh strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ $ git checkout -b <branch name>
 **Commit your changes**
 
 ```bash
-$ git commit -a -m "Follow the conventional commit messages style to write this message"
+$ git commit -a -m 'Follow the conventional commit messages style to write this message'
 ```
 
 **Push to the branch**


### PR DESCRIPTION
When there is no variable expansion going on there shall not be double quotes.