### PR TITLE
fix: follow no-loc-expr-outside-params lint rule

### DIFF
--- a/images-to-azure-storage-account/main.bicep
+++ b/images-to-azure-storage-account/main.bicep
@@ -9,7 +9,7 @@
 @description('Email address to receive system notifications sent from API Management.')
 param publisherEmail string
 
-@description('The location to deploy resources in.')
+@description('The location to deploy all resources in.')
 param location string = resourceGroup().location
 
 var commonName = 'image-upload-${uniqueString(resourceGroup().id)}'

--- a/images-to-azure-storage-account/main.bicep
+++ b/images-to-azure-storage-account/main.bicep
@@ -9,6 +9,9 @@
 @description('Email address to receive system notifications sent from API Management.')
 param publisherEmail string
 
+@description('The location to deploy resources in.')
+param location string = resourceGroup().location
+
 var commonName = 'image-upload-${uniqueString(resourceGroup().id)}'
 
 // -----------------------------------------------------------------------------
@@ -18,8 +21,6 @@ var commonName = 'image-upload-${uniqueString(resourceGroup().id)}'
 // storage-blob-data-contributor built-in role
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor
 var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
-
-param location string = resourceGroup().location
 
 resource storage 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'image${uniqueString(resourceGroup().id)}'

--- a/images-to-azure-storage-account/main.bicep
+++ b/images-to-azure-storage-account/main.bicep
@@ -19,9 +19,11 @@ var commonName = 'image-upload-${uniqueString(resourceGroup().id)}'
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor
 var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
 
+param location string = resourceGroup().location
+
 resource storage 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'image${uniqueString(resourceGroup().id)}'
-  location: resourceGroup().location
+  location: location
   sku: {
     name: 'Standard_LRS'
   }
@@ -52,7 +54,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-08-01-prev
 
 resource apiService 'Microsoft.ApiManagement/service@2021-01-01-preview' = {
   name: commonName
-  location: resourceGroup().location
+  location: location
   sku: {
     capacity: 0
     name: 'Consumption'

--- a/images-to-azure-storage-account/main.json
+++ b/images-to-azure-storage-account/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "15233226151138971912"
+      "templateHash": "2888457892500370732"
     }
   },
   "parameters": {
@@ -14,6 +14,10 @@
       "metadata": {
         "description": "Email address to receive system notifications sent from API Management."
       }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
     }
   },
   "variables": {
@@ -158,7 +162,7 @@
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2021-04-01",
       "name": "[format('image{0}', uniqueString(resourceGroup().id))]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "sku": {
         "name": "Standard_LRS"
       },
@@ -182,7 +186,7 @@
       "type": "Microsoft.ApiManagement/service",
       "apiVersion": "2021-01-01-preview",
       "name": "[variables('commonName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "sku": {
         "capacity": 0,
         "name": "Consumption"

--- a/images-to-azure-storage-account/main.json
+++ b/images-to-azure-storage-account/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "2888457892500370732"
+      "templateHash": "10401452965887447216"
     }
   },
   "parameters": {
@@ -17,7 +17,10 @@
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location to deploy all resources in."
+      }
     }
   },
   "variables": {


### PR DESCRIPTION
Uses `resourceGroup().location` with a param according to `no-loc-expr-outside-params` lint rule.