### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/bicep-to-arm.yml
+++ b/.github/workflows/bicep-to-arm.yml
@@ -6,6 +6,9 @@ on:
       - '**.bicep'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/images-to-azure-storage-account.yml
+++ b/.github/workflows/images-to-azure-storage-account.yml
@@ -7,6 +7,9 @@ on:
       - images-to-azure-storage-account/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-uri.yml
+++ b/.github/workflows/static-uri.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/telemetry-to-azure-iot-edge.yml
+++ b/.github/workflows/telemetry-to-azure-iot-edge.yml
@@ -7,6 +7,9 @@ on:
       - telemetry-to-azure-iot-edge/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: static analysis

--- a/.github/workflows/telemetry-to-azure-iot-hub.yml
+++ b/.github/workflows/telemetry-to-azure-iot-hub.yml
@@ -7,6 +7,9 @@ on:
       - telemetry-to-azure-iot-hub/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/bicep-to-arm.yml`
- `.github/workflows/images-to-azure-storage-account.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/static-uri.yml`
- `.github/workflows/telemetry-to-azure-iot-edge.yml`
- `.github/workflows/telemetry-to-azure-iot-hub.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.