### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/bicep-to-arm.yml
+++ b/.github/workflows/bicep-to-arm.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: az bicep install
       - name: Transpile all 'main.bicep' templates
         run: find . -name 'main.bicep' -exec az bicep build --file {} \;

--- a/.github/workflows/images-to-azure-storage-account.yml
+++ b/.github/workflows/images-to-azure-storage-account.yml
@@ -14,5 +14,5 @@ jobs:
       run:
         working-directory: images-to-azure-storage-account
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: az bicep build --file main.bicep

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
-      - uses: github/super-linter/slim@v5
+      - uses: github/super-linter/slim@45fc0d88288beee4701c62761281edfee85655d7 # v5.0.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/telemetry-to-azure-iot-edge.yml
+++ b/.github/workflows/telemetry-to-azure-iot-edge.yml
@@ -15,6 +15,6 @@ jobs:
       run:
         working-directory: telemetry-to-azure-iot-edge
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: shellcheck ./create-certificates.sh
       - run: shellcheck ./create-cloud-resources.sh

--- a/.github/workflows/telemetry-to-azure-iot-hub.yml
+++ b/.github/workflows/telemetry-to-azure-iot-hub.yml
@@ -14,5 +14,5 @@ jobs:
       run:
         working-directory: telemetry-to-azure-iot-hub
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: az bicep build --file main.bicep


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Pinned-Dependencies** remedy.

It pins the GitHub Actions used in the following workflows to full commit SHAs, keeping the original version as a trailing comment:

- `.github/workflows/bicep-to-arm.yml`
- `.github/workflows/images-to-azure-storage-account.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/telemetry-to-azure-iot-edge.yml`
- `.github/workflows/telemetry-to-azure-iot-hub.yml`

Renovate recognises the `@<sha> # <version>` format and will keep these pinned actions updated automatically.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#pinned-dependencies) for details.